### PR TITLE
Update checklist.md

### DIFF
--- a/checklist.md
+++ b/checklist.md
@@ -670,13 +670,13 @@ Only nos. 4, 8, 9 and 14 (from the Michigan collection) were previously unpublis
  * III, ed. J. Bazant, H. Harrauer and R. Pinaudi with many others. Prague 2010. (Eirene 46 [2010] pages 1–149). Nos. 1–37. <ddb:p.eirene;3>
  * IV, ed. H. Harrauer and R. Pinaudi with many others. Prague 2016. (Eirene 52 [2016] pages 1–290). Nos. 1–50. <ddb:p.eirene;4>
 
-### <a id="P.Eleph.">P.Eleph.</a> (see [O.Eleph.Wagner](#O.Eleph.Wagner))
+### <a id="P.Eleph.">P.Eleph.</a>
+= _Aegyptische Urkunden aus den Königlichen Museen in Berlin: Griechische Urkunden_, Sonderheft. _Elephantine-Papyri_, ed. O. Rubensohn. Berlin 1907. Nos. 1—32 and 3 fragments. [MF 2.81; rp. CG] <ddb:p.eleph> [Online: archive.org](https://archive.org/details/elephantinepapyr00rube)
 
 ### <a id="P.Eleph.Dem.">P.Eleph.Dem.</a>
 = _Demotische Papyrus von der Insel Elephantine_, ed. W. Spiegelberg. Leipzig 1908. (Dem.Stud. 2). Nos. 1—13; nos. 5—7 and 12 have Greek subscriptions. [Online: archive.org](https://archive.org/details/bub_gb_jyHgAAAAMAAJ)
 
-### <a id="P.Eleph.Wagner">P.Eleph.Wagner</a>
-= _Elephantine XIII: Les papyrus et les ostraca grecs d'Elephantine_, ed. G. Wagner. Mainz 1998. (Deutsches Archäologisches Institut (Kairo), Archäologische Veröffentlichungen 70). Papyri nos. I—IV; ostraca nos. 1—372; nos. 166—278 are descripta. [PvZ] <ddb:p.eleph.wagner>
+### <a id="P.Eleph.Wagner">P.Eleph.Wagner</a> (see [O.Eleph.Wagner](#O.Eleph.Wagner))
 
 ### <a id="P.Enteux.">P.Enteux.</a>
 = _ΕΝΤΕΥΞΕΙΣ: Requêtes et plaintes adressées au Roi d'Égypte au IIIe siècle avant J.-C._, ed. O. Guéraud. Cairo 1931—32. (Publ.Soc.Fouad I). Nos. 1—113 and appendix of 4 texts. [MF 1.52] <ddb:p.enteux>


### PR DESCRIPTION
Cleaned mistake in P.Eleph. entries. It is P.Eleph.Wagner that should cross-reference to O.Eleph.Wagner, not P.Eleph.